### PR TITLE
Add stopAnimation method

### DIFF
--- a/src/AnimatedCircularProgress.js
+++ b/src/AnimatedCircularProgress.js
@@ -48,6 +48,10 @@ export default class AnimatedCircularProgress extends React.PureComponent {
     return this.timingFunction;
   }
   
+  setAnimatedValue(value) {
+    this.state.fillAnimation.setValue(value);
+  }
+  
   stopAnimation() {
     if(this.timingFunction) this.timingFunction.stop();
   }

--- a/src/AnimatedCircularProgress.js
+++ b/src/AnimatedCircularProgress.js
@@ -27,6 +27,9 @@ export default class AnimatedCircularProgress extends React.PureComponent {
     if (prevProps.fill !== this.props.fill) {
       this.animate();
     }
+    if (prevProps.prefill !== this.props.prefill) {
+      this.state.fillAnimation.setValue(this.props.prefill);
+    }
   }
 
   animate(toVal, dur, ease) {

--- a/src/AnimatedCircularProgress.js
+++ b/src/AnimatedCircularProgress.js
@@ -13,6 +13,7 @@ const AnimatedProgress = Animated.createAnimatedComponent(CircularProgress);
 export default class AnimatedCircularProgress extends React.PureComponent {
   constructor(props) {
     super(props);
+    this.timingFunction = null;
     this.state = {
       fillAnimation: new Animated.Value(props.prefill)
     }
@@ -33,11 +34,19 @@ export default class AnimatedCircularProgress extends React.PureComponent {
     const duration = dur || this.props.duration;
     const easing = ease || this.props.easing;
 
-    return Animated.timing(this.state.fillAnimation, {
+    this.timingFunction = Animated.timing(this.state.fillAnimation, {
       toValue,
       easing,
       duration,
-    }).start(this.props.onAnimationComplete);
+    });
+    
+    this.timingFunction.start(this.props.onAnimationComplete);
+    
+    return this.timingFunction;
+  }
+  
+  stopAnimation() {
+    if(this.timingFunction) this.timingFunction.stop();
   }
 
   render() {


### PR DESCRIPTION
This adds a `stopAnimation` method that calls the `.stop()` method on the `Animated` timing function and would be a solution for this https://github.com/bgryszko/react-native-circular-progress/issues/113