### PR TITLE
overflow:hidden added and now fill in image, border radius work in android

### DIFF
--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -52,7 +52,8 @@ export default class CircularProgress extends React.PureComponent {
       height: offset,
       borderRadius: offset / 2,
       alignItems: 'center',
-      justifyContent: 'center'
+      justifyContent: 'center',
+      overflow: 'hidden'
     };
 
     return (


### PR DESCRIPTION
Example I tried like that
 <AnimatedCircularProgress
                    ..............
                    >
                      {fill => (
                        <Image
                          source={require('../assets/icons/image.png')}
                          style={{
                            height: 70,
                            width: 70,
                          }}
                          borderRadius={35}
                          resizeMode="cover"
                        />
                      )}
                    </AnimatedCircularProgress>
borderRadius work in Ios perfectly but android is don't is react native issue (https://github.com/facebook/react-native/issues/2468#)
to solve this problem, giving the View overflow: 'hidden' I added that