### PR TITLE
Fix issue with circle not animating when `fill` is equal to `0`

### DIFF
--- a/src/AnimatedCircularProgress.js
+++ b/src/AnimatedCircularProgress.js
@@ -35,7 +35,7 @@ export default class AnimatedCircularProgress extends React.PureComponent {
   }
 
   animate(toVal, dur, ease) {
-    const toValue = toVal || this.props.fill;
+    const toValue = toVal >= 0 ? toVal : this.props.fill;
     const duration = dur || this.props.duration;
     const easing = ease || this.props.easing;
 


### PR DESCRIPTION
This PR fixes #172.

The issue was that there's a comparison [here](https://github.com/bartgryszko/react-native-circular-progress/blob/681413a2c22940d101977a2f9899895a380ef21b/src/AnimatedCircularProgress.js#L38) that will fallback to `this.props.fill` when `toVal` is equal to `0`.

To test this you can simply use `AnimatedCircularProgress` with `prefil={100}` and then call `this.animatedCircularProgress.animate(0)`.