### PR TITLE
Fix circle not disappearing completely when `fill` is equal to zero

### DIFF
--- a/src/AnimatedCircularProgress.js
+++ b/src/AnimatedCircularProgress.js
@@ -35,7 +35,7 @@ export default class AnimatedCircularProgress extends React.PureComponent {
   }
 
   animate(toVal, dur, ease) {
-    const toValue = toVal || this.props.fill;
+    const toValue = toVal >= 0 ? toVal : this.props.fill;
     const duration = dur || this.props.duration;
     const easing = ease || this.props.easing;
 

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -73,13 +73,15 @@ export default class CircularProgress extends React.PureComponent {
                 fill="transparent"
               />
             )}
-            <Path
-              d={circlePath}
-              stroke={tintColor}
-              strokeWidth={width}
-              strokeLinecap={lineCap}
-              fill="transparent"
-            />
+            {fill > 0 && (
+              <Path
+                d={circlePath}
+                stroke={tintColor}
+                strokeWidth={width}
+                strokeLinecap={lineCap}
+                fill="transparent"
+              />
+            )}
           </G>
         </Svg>
         {children && (


### PR DESCRIPTION
**This PR contains #173 so it's better to review that one before this.**

When going through the issue #172 I noticed that even if you animate to `0` there's a _leftover_ of the circle:

![](https://user-images.githubusercontent.com/6207220/53396096-e7a03700-39a3-11e9-9798-b43a05d3ab3c.gif)

With this PR, this is how it looks:

![kapture 2019-02-26 at 9 02 46](https://user-images.githubusercontent.com/6207220/53396668-503be380-39a5-11e9-880b-93812f6373ba.gif)

**I'm not sure if the solution is the best so I am open for suggestions!**
