### PR TITLE
FixCroppedCircles

### DIFF
--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -43,11 +43,14 @@ export default class CircularProgress extends React.PureComponent {
     const backgroundPath = this.circlePath(size / 2, size / 2, size / 2 - width / 2, 0, arcSweepAngle);
     const circlePath = this.circlePath(size / 2, size / 2, size / 2 - width / 2, 0, arcSweepAngle * this.clampFill(fill) / 100);
     const offset = size - (width * 2);
+    const adjustedSize = backgroundWidth > width ? size + width : size;
+    const adjustedOrigin = backgroundWidth > width ? width / 2 : 0;
+    const adjustedPosition = backgroundWidth > width ? width * 1.5 : width;
 
     const childContainerStyle = {
       position: 'absolute',
-      left: width,
-      top: width,
+      left: adjustedPosition,
+      top: adjustedPosition,
       width: offset,
       height: offset,
       borderRadius: offset / 2,
@@ -59,13 +62,15 @@ export default class CircularProgress extends React.PureComponent {
     return (
       <View style={style}>
         <Svg
-          width={size}
-          height={size}
+          width={adjustedSize}
+          height={adjustedSize}
           style={{ backgroundColor: 'transparent' }}
         >
-          <G rotation={rotation} originX={size/2} originY={size/2}>
+          <G rotation={rotation} originX={adjustedSize/2} originY={adjustedSize/2}>
             { backgroundColor && (
               <Path
+                x={adjustedOrigin}
+                y={adjustedOrigin}
                 d={backgroundPath}
                 stroke={backgroundColor}
                 strokeWidth={backgroundWidth || width}
@@ -75,6 +80,8 @@ export default class CircularProgress extends React.PureComponent {
             )}
             {fill > 0 && (
               <Path
+                x={adjustedOrigin}
+                y={adjustedOrigin}
                 d={circlePath}
                 stroke={tintColor}
                 strokeWidth={width}


### PR DESCRIPTION
When having something like: 

`<AnimatedCircularProgress size={210} width={20} fill={20} rotation={0} backgroundWidth={30} tintColor={color.Yellow} backgroundColor={color.LightBlue} lineCap='round' > { (fill) => ( this.renderInnerText() ) } </AnimatedCircularProgress> `
I got cropped circles 
<img width="203" alt="Screen Shot 2019-03-04 at 12 07 15 PM" src="https://user-images.githubusercontent.com/12516663/54246863-3994a100-44fc-11e9-84c1-45be34b71a27.png">

this PR address this and we have a better result:
<img width="212" alt="Screen Shot 2019-03-12 at 7 24 26 PM" src="https://user-images.githubusercontent.com/12516663/54246963-9a23de00-44fc-11e9-8046-ddc783c01352.png">

