### PR TITLE
fix default import of react

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'react-native-circular-progress' {
-  import React from 'react';
+  import * as React from 'react';
   import { Animated, Easing } from 'react-native';
 
   export interface AnimatedCircularProgressProps {


### PR DESCRIPTION
Hi, thank you for the great library.

For those who set `"allowSyntheticDefaultImports": false` in `tsconfig.json`, `import * as React from 'react'` is needed.

I am very glad if you merge this PR.

Best regards,