### PR TITLE
Add support for rendering custom "cap" at tip of progress circle

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ You can also define a function that'll receive current progress and for example 
 </AnimatedCircularProgress>
 ```
 
+You can also define a function that'll receive the location at the top of the progress circle and render a custom SVG element:
+
+```jsx
+<AnimatedCircularProgress
+  size={120}
+  width={15}
+  fill={100}
+  tintColor="#00e0ff"
+  backgroundColor="#3d5875"
+  padding={10}
+  renderCap={({ center }) => <Circle cx={center.x} cy={center.y} r="10" fill="blue" />}
+  />
+```
+
 Finally, you can manually trigger a duration-based timing animation by putting a ref on the component and calling the `animate(toValue, duration, easing)` function like so:
 
 ```jsx
@@ -86,6 +100,9 @@ arcSweepAngle         | number (0-360)         | 360                     | If yo
 style                 | ViewPropTypes.style    |                         | Extra styling for the main container
 children              | function               |                         | Pass a function as a child. It receiveds the current fill-value as an argument
 childrenContainerStyle| ViewPropTypes.style    |                         | Extra styling for the children container
+padding               | number                 | 0                       | Padding applied around the circle to allow for a cap that bleeds outside its boundary
+renderCap             | function               | undefined               | Function that's invoked during rendering to draw at the tip of the progress circle
+
 
 The following props can further be used on `AnimatedCircularProgress`:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -129,6 +129,22 @@ declare module 'react-native-circular-progress' {
      *
      */
     onAnimationComplete?: (event: { finished: boolean }) => void;
+
+    /**
+     * Padding applied around the circle to allow for a cap that bleeds outside its boundary
+     *
+     * @type {number}
+     * @default 0
+     */
+    padding?: number;
+
+    /**
+     * Function that's invoked during rendering to draw at the tip of the progress circle
+     *
+     */
+    renderCap?: (payload: {
+      center: { x: number; y: number };
+    }) => React.ReactNode;
   }
 
   export class AnimatedCircularProgress extends React.Component<

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -36,31 +36,44 @@ export default class CircularProgress extends React.PureComponent {
       fill,
       children,
       childrenContainerStyle,
+      padding,
+      renderCap,
     } = this.props;
 
     const maxWidthCircle = backgroundWidth ? Math.max(width, backgroundWidth) : width;
+    const sizeWithPadding = size / 2 + padding / 2;
+    const radius = size / 2 - maxWidthCircle / 2 - padding / 2;
 
     const backgroundPath = this.circlePath(
-      size / 2,
-      size / 2,
-      size / 2 - maxWidthCircle / 2,
+      sizeWithPadding,
+      sizeWithPadding,
+      radius,
       0,
       arcSweepAngle
     );
+    const currentFillAngle = (arcSweepAngle * this.clampFill(fill)) / 100;
     const circlePath = this.circlePath(
-      size / 2,
-      size / 2,
-      size / 2 - maxWidthCircle / 2,
+      sizeWithPadding,
+      sizeWithPadding,
+      radius,
       0,
-      (arcSweepAngle * this.clampFill(fill)) / 100
+      currentFillAngle
     );
+    const coordinate = this.polarToCartesian(
+      sizeWithPadding,
+      sizeWithPadding,
+      radius,
+      currentFillAngle
+    );
+    const cap = this.props.renderCap ? this.props.renderCap({ center: coordinate }) : null;
+
     const offset = size - maxWidthCircle * 2;
 
     const localChildrenContainerStyle = {
       ...{
         position: 'absolute',
-        left: maxWidthCircle,
-        top: maxWidthCircle,
+        left: maxWidthCircle + padding / 2,
+        top: maxWidthCircle + padding / 2,
         width: offset,
         height: offset,
         borderRadius: offset / 2,
@@ -73,7 +86,7 @@ export default class CircularProgress extends React.PureComponent {
 
     return (
       <View style={style}>
-        <Svg width={size} height={size} style={{ backgroundColor: 'transparent' }}>
+        <Svg width={size + padding} height={size + padding}>
           <G rotation={rotation} originX={size / 2} originY={size / 2}>
             {backgroundColor && (
               <Path
@@ -93,6 +106,7 @@ export default class CircularProgress extends React.PureComponent {
                 fill="transparent"
               />
             )}
+            {cap}
           </G>
         </Svg>
         {children && <View style={localChildrenContainerStyle}>{children(fill)}</View>}
@@ -114,6 +128,8 @@ CircularProgress.propTypes = {
   arcSweepAngle: PropTypes.number,
   children: PropTypes.func,
   childrenContainerStyle: ViewPropTypes.style,
+  padding: PropTypes.number,
+  renderCap: PropTypes.func,
 };
 
 CircularProgress.defaultProps = {
@@ -121,4 +137,5 @@ CircularProgress.defaultProps = {
   rotation: 90,
   lineCap: 'butt',
   arcSweepAngle: 360,
+  paddinig: 0,
 };


### PR DESCRIPTION
Adds two new props

* padding - adds space around the circle to allow for a cap that bleeds over without clipping
* renderCap - a function that returns the Svg component to draw

Closes https://github.com/bartgryszko/react-native-circular-progress/issues/202