### PR TITLE
Fix array of zeros on iOS

### DIFF
--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -89,8 +89,10 @@ export default class CircularProgress extends React.PureComponent {
       ? dashedBackground
       : { width:0, gap:0 };
 
-    const strokeDasharray = Object.values(dashedBackgroundStyle)
-      .map(value => parseInt(value));
+    const strokeDasharray = dashedBackground.gap > 0 ? 
+    Object.values(dashedBackgroundStyle)
+      .map(value => parseInt(value)) 
+      : null;
 
     return (
       <View style={style}>


### PR DESCRIPTION
The output of warning was being caused on every fill progress update if dash style wasn't provided so it resulted in array of eros [0,0]. 
`CGContextSetLineDash: invalid dash array: at least one element must be non-zero`