### PR TITLE
Add explicit useNativeDriver to AnimatedCircularProgress

### DIFF
--- a/src/AnimatedCircularProgress.js
+++ b/src/AnimatedCircularProgress.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Animated, AppState, Easing, View, ViewPropTypes } from 'react-native';
+import { Animated, Easing } from 'react-native';
 import CircularProgress from './CircularProgress';
 const AnimatedProgress = Animated.createAnimatedComponent(CircularProgress);
 
@@ -35,8 +35,10 @@ export default class AnimatedCircularProgress extends React.PureComponent {
     const toValue = toVal >= 0 ? toVal : this.props.fill;
     const duration = dur || this.props.duration;
     const easing = ease || this.props.easing;
+    const useNativeDriver = this.props.useNativeDriver;
     
     const anim = Animated.timing(this.state.fillAnimation, {
+      useNativeDriver,
       toValue,
       easing,
       duration,
@@ -72,10 +74,12 @@ AnimatedCircularProgress.propTypes = {
   duration: PropTypes.number,
   easing: PropTypes.func,
   onAnimationComplete: PropTypes.func,
+  useNativeDriver: PropTypes.bool,
 };
 
 AnimatedCircularProgress.defaultProps = {
   duration: 500,
   easing: Easing.out(Easing.ease),
   prefill: 0,
+  useNativeDriver: true,
 };


### PR DESCRIPTION
Added `userNativeDriver` explicitly to prevent new warnings in RN 0.62-rc0:
```
WARN  Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false`
```