### PR TITLE
Fix: useNativeDriver cause props undefined.

### DIFF
--- a/src/AnimatedCircularProgress.js
+++ b/src/AnimatedCircularProgress.js
@@ -52,7 +52,7 @@ export default class AnimatedCircularProgress extends React.PureComponent {
     if (!this.props.tintColorSecondary) {
       return this.props.tintColor
     }
-    
+
     const tintAnimation = this.state.fillAnimation.interpolate({
       inputRange: [0, 100],
       outputRange: [this.props.tintColor, this.props.tintColorSecondary]
@@ -81,5 +81,5 @@ AnimatedCircularProgress.defaultProps = {
   duration: 500,
   easing: Easing.out(Easing.ease),
   prefill: 0,
-  useNativeDriver: true,
+  useNativeDriver: false,
 };


### PR DESCRIPTION
This pull is just a hotfix for `useNativeDriver` problem 
and also keep the original intent of issue merge #227 .  Also check the discussion on #228.

Related Issues:   #228 #229 #231 #232 

It seems like `useNativeDriver` has limit support (check: https://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated#caveats ), and `react-native-svg`,`react-native` library also has some similar issues regarding to this problem (not sure it's a bug or it is just not supported because one of them are label as MaybeFix by RN).

Since the `set useNativeDriver`  warning is generated by `RN 0.62-rc0`, which is not even a stable release from React-Native. I was unable to quickly test out the change (and other implementations that try to utilize the `userNativeDriver`) in that version (EXPO only supports the newest stable release). I believe it's too early to worry about that warning. Probably someone can try it out? or just leave it alone until the 0.62 stable release out.


