### PR TITLE
Add dashed type and transparency for bar fill

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,14 @@ declare module 'react-native-circular-progress' {
     fill?: number;
 
     /**
+     * Current progress / fillTransparency
+     *
+     * @type {boolean}
+     * @default true
+     */
+    fillTransparency?: boolean;
+
+    /**
      * Color of the progress line
      *
      * @type {string}
@@ -49,7 +57,7 @@ declare module 'react-native-circular-progress' {
 
     /**
      * Change the fill color from tintColor to tintColorSecondary as animation progresses.
-     * 
+     *
      * @type {string}
      * @default 'undefined'
      */
@@ -153,6 +161,14 @@ declare module 'react-native-circular-progress' {
     renderCap?: (payload: {
       center: { x: number; y: number };
     }) => React.ReactNode;
+
+    /**
+     * Use dashed type for fill
+     *
+     * @type { width: number; gap: number }
+     * @default '{ width: 0, gap: 0 }'
+     */
+    dashedFill?: { width: number; gap: number };
 
     /**
      * Use dashed type for background

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -34,24 +34,25 @@ export default class CircularProgress extends React.PureComponent {
       lineCap,
       arcSweepAngle,
       fill,
+      fillTransparency,
       children,
       childrenContainerStyle,
       padding,
       renderCap,
       dashedBackground,
+      dashedFill
     } = this.props;
 
     const maxWidthCircle = backgroundWidth ? Math.max(width, backgroundWidth) : width;
     const sizeWithPadding = size / 2 + padding / 2;
     const radius = size / 2 - maxWidthCircle / 2 - padding / 2;
 
-   
     const currentFillAngle = (arcSweepAngle * this.clampFill(fill)) / 100;
-     const backgroundPath = this.circlePath(
+    const backgroundPath = this.circlePath(
       sizeWithPadding,
       sizeWithPadding,
       radius,
-      currentFillAngle,
+      fillTransparency ? 0 : currentFillAngle,
       arcSweepAngle
     );
     const circlePath = this.circlePath(
@@ -86,13 +87,14 @@ export default class CircularProgress extends React.PureComponent {
       ...childrenContainerStyle,
     }
 
-    const dashedBackgroundStyle = dashedBackground.gap > 0
-      ? dashedBackground
-      : { width:0, gap:0 };
+    const strokeDasharrayFill = dashedFill.gap > 0 ?
+      Object.values(dashedFill)
+      .map(value => parseInt(value))
+      : null;
 
-    const strokeDasharray = dashedBackground.gap > 0 ? 
-    Object.values(dashedBackgroundStyle)
-      .map(value => parseInt(value)) 
+    const strokeDasharrayBackground = dashedBackground.gap > 0 ?
+      Object.values(dashedBackground)
+      .map(value => parseInt(value))
       : null;
 
     return (
@@ -105,7 +107,7 @@ export default class CircularProgress extends React.PureComponent {
                 stroke={backgroundColor}
                 strokeWidth={backgroundWidth || width}
                 strokeLinecap={lineCap}
-                strokeDasharray={strokeDasharray}
+                strokeDasharray={strokeDasharrayBackground}
                 fill="transparent"
               />
             )}
@@ -115,7 +117,7 @@ export default class CircularProgress extends React.PureComponent {
                 stroke={tintColor}
                 strokeWidth={width}
                 strokeLinecap={lineCap}
-                strokeDasharray={strokeDasharray}
+                strokeDasharray={strokeDasharrayFill}
                 fill="transparent"
               />
             )}
@@ -132,6 +134,7 @@ CircularProgress.propTypes = {
   style: ViewPropTypes.style,
   size: PropTypes.number.isRequired,
   fill: PropTypes.number.isRequired,
+  fillTransparency: PropTypes.boolean,
   width: PropTypes.number.isRequired,
   backgroundWidth: PropTypes.number,
   tintColor: PropTypes.string,
@@ -144,6 +147,7 @@ CircularProgress.propTypes = {
   padding: PropTypes.number,
   renderCap: PropTypes.func,
   dashedBackground: PropTypes.object,
+  dashedFill: PropTypes.object
 };
 
 CircularProgress.defaultProps = {
@@ -153,4 +157,6 @@ CircularProgress.defaultProps = {
   arcSweepAngle: 360,
   padding: 0,
   dashedBackground: { width: 0, gap: 0 },
+  dashedFill: { width: 0, gap: 0 },
+  fillTransparency: true
 };


### PR DESCRIPTION
The #236  PR **forces** the fill to have to same dashed type as background, which create some undesired looking when we want to dash the background only. 
So based on the idea of  PR, I implement the entire dashed type as well as the fill Transparency for fill (including Typescript support) so we are able to control them individually. 

```
<AnimatedCircularProgress
dashedBackground={{width: 20, gap: 10}}
dashedFill={{width: 10, gap:20}}
fillTransparency={false}
>
```
Code result:
![image](https://user-images.githubusercontent.com/35160613/74902251-79ead900-5373-11ea-8160-ab986e96b23a.png)

fillTransparency true | false , without given dashedBackground | dashedFill
![image](https://user-images.githubusercontent.com/35160613/74902302-9f77e280-5373-11ea-8274-b5be0dbc6271.png)
![image](https://user-images.githubusercontent.com/35160613/74902378-e5cd4180-5373-11ea-8431-d7083e959566.png)
![image](https://user-images.githubusercontent.com/35160613/74902566-6db34b80-5374-11ea-9b15-74d98aec3f5b.png)




