### PR TITLE
feat(linecap): add control fill line cap separately from arc line cap

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,14 @@ declare module 'react-native-circular-progress' {
     lineCap?: 'butt' | 'round' | 'square';
 
     /**
+     * Shape used at ends of progress line.
+     *
+     * @type {('butt' | 'round' | 'square')}
+     * @default lineCap - which is 'butt'
+     */
+    fillLineCap?: 'butt' | 'round' | 'square';
+
+    /**
      * If you don't want a full circle, specify the arc angle
      *
      * @type {number}

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -33,6 +33,7 @@ export default class CircularProgress extends React.PureComponent {
       style,
       rotation,
       lineCap,
+      fillLineCap = lineCap,
       arcSweepAngle,
       fill,
       children,
@@ -116,7 +117,7 @@ export default class CircularProgress extends React.PureComponent {
                 d={circlePath}
                 stroke={tintColor}
                 strokeWidth={width}
-                strokeLinecap={lineCap}
+                strokeLinecap={fillLineCap}
                 strokeDasharray={strokeDasharrayTint}
                 fill="transparent"
               />


### PR DESCRIPTION
I needed the ability to change the fill lineCap separately from the arc lineCap.
It'll default to whatever `lineCap` is set to (so `butt` for now).