### PR TITLE
fixed crash  if onFillChange is not provided

### DIFF
--- a/src/AnimatedCircularProgress.js
+++ b/src/AnimatedCircularProgress.js
@@ -10,10 +10,11 @@ export default class AnimatedCircularProgress extends React.PureComponent {
     this.state = {
       fillAnimation: new Animated.Value(props.prefill),
     };
-
-    this.state.fillAnimation.addListener(({ value }) =>
-      props.onFillChange(value)
-    );
+    if(props.onFillChange){
+      this.state.fillAnimation.addListener(({ value }) =>
+        props.onFillChange(value)
+      );
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
onFillChange is not required by default.