### PR TITLE
Add 'useNativeDriver' prop to TS definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ easing              | function               | Easing.out(Easing.ease) | Animati
 onAnimationComplete | function               |                         | Function that's invoked when the animation completes (both on mount and if called with `.animate()`)
 onFillChange        | function               |                         | Function that returns current progress on every change
 tintColorSecondary  | string                 | the same as tintColor   | To change fill color from tintColor to tintColorSecondary as animation progresses
+useNativeDriver     | boolean                | false                   | Whether to use react-native Animated's native driver
 
 `AnimatedCircularProgress` also exposes the following functions:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -186,6 +186,14 @@ declare module 'react-native-circular-progress' {
      * @default '{ width: 0, gap: 0 }'
      */
     dashedBackground?: { width: number; gap: number };
+
+    /**
+     * Use react-native Animated's native driver for animations
+     * 
+     * @type {boolean}
+     * @default false
+     */
+    useNativeDriver?: boolean;
   }
 
   export class AnimatedCircularProgress extends React.Component<


### PR DESCRIPTION
It appears the the AnimatedCircularProgress component waits for a "useNativeDriver" prop, but that one prop wasn't declared in  the TS definition file.
This PR updates the AnimatedCircularProgressProps interface in the TS declaration file in order to add this "useNativeDriver" prop.