### PR TITLE
Update typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,20 +25,19 @@ declare module 'react-native-circular-progress' {
     width: number;
 
     /**
+     * Current progress / fill
+     *
+     * @type {number}
+     */
+    fill: number;
+
+    /**
      * Thickness of background circle
      *
      * @type {number}
      * @default width
      */
     backgroundWidth?: number;
-
-    /**
-     * Current progress / fill
-     *
-     * @type {number}
-     * @default 0
-     */
-    fill?: number;
 
     /**
      * Color of the progress line


### PR DESCRIPTION
The prop `fill` is marked as required in the propTypes for `CircularProgress` but is optional in the Typescript type declaration. This results in Typescript not complaining when leaving the prop empty, while propTypes generates the following warning during runtime: `Failed prop type: The prop 'fill' is marked as required in 'AnimatedCircularProgress', but its value is 'undefined'.`. The fix is to change the Typescript declaration for `fill` from optional to required.