### PR TITLE
Customize the maximum value of full circle

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ padding               | number                 | 0                       | Paddi
 dashedBackground      | object                 | { width: 0, gap: 0 }    | Bar background as dashed type
 dashedTint            | object                 | { width: 0, gap: 0 }    | Bar tint as dashed type
 renderCap             | function               | undefined               | Function that's invoked during rendering to draw at the tip of the progress circle
+maximumValue             | number               | 100               | Set your maximum value for the full circle
 
 The following props can further be used on `AnimatedCircularProgress`:
 

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -41,14 +41,15 @@ export default class CircularProgress extends React.PureComponent {
       padding,
       renderCap,
       dashedBackground,
-      dashedTint
+      dashedTint,
+      maximumValue = 100
     } = this.props;
 
     const maxWidthCircle = backgroundWidth ? Math.max(width, backgroundWidth) : width;
     const sizeWithPadding = size / 2 + padding / 2;
     const radius = size / 2 - maxWidthCircle / 2 - padding / 2;
 
-    const currentFillAngle = (arcSweepAngle * this.clampFill(fill)) / 100;
+    const currentFillAngle = (arcSweepAngle * this.clampFill(fill)) / maximumValue;
     const backgroundPath = this.circlePath(
       sizeWithPadding,
       sizeWithPadding,


### PR DESCRIPTION
I added a new prop for maximum value which was 100 and its default is 100 now. I need to set a totally different maximum value logic and this prop simply solves it. 

It makes the library more customizable now.

Thank you for the library tho! It is awesome!
@bartgryszko 


Here is the basic example of the `maximumValue` prop. In this example the `maximumValue` is `8` and `fill` is `2` so the circle is working with the maximum value now.

<img width="90" alt="CleanShot 2021-07-28 at 1 10 53@2x" src="https://user-images.githubusercontent.com/6813862/127234196-13c3e00c-9c3a-4d98-a1d8-eb157b81cb0d.png">
