### PR TITLE
Add delay to animated circular progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Name                | Type                   | Default value           | Descrip
 --------------------|------------------------|-------------------------|--------------
 prefill             | number (0-100)         | 0                       | Initial fill-value before animation starts
 duration            | number                 | 500                     | Duration of animation in ms
+delay               | number                 | 0                       | Delay of animation in ms
 easing              | function               | Easing.out(Easing.ease) | Animation easing function
 onAnimationComplete | function               |                         | Function that's invoked when the animation completes (both on mount and if called with `.animate()`)
 onFillChange        | function               |                         | Function that returns current progress on every change

--- a/index.d.ts
+++ b/index.d.ts
@@ -142,6 +142,14 @@ declare module 'react-native-circular-progress' {
     duration?: number;
 
     /**
+     * Delay of animation in ms
+     *
+     * @type {number}
+     * @default 0
+     */
+    delay?: number;
+
+    /**
      *
      * @type {Function}
      * @default Easing.out(Easing.ease)

--- a/src/AnimatedCircularProgress.js
+++ b/src/AnimatedCircularProgress.js
@@ -10,7 +10,7 @@ export default class AnimatedCircularProgress extends React.PureComponent {
     this.state = {
       fillAnimation: new Animated.Value(props.prefill),
     };
-    if(props.onFillChange){
+    if (props.onFillChange) {
       this.state.fillAnimation.addListener(({ value }) =>
         props.onFillChange(value)
       );
@@ -41,12 +41,14 @@ export default class AnimatedCircularProgress extends React.PureComponent {
     const duration = dur || this.props.duration;
     const easing = ease || this.props.easing;
     const useNativeDriver = this.props.useNativeDriver;
+    const delay = this.props.delay;
 
     const anim = Animated.timing(this.state.fillAnimation, {
       useNativeDriver,
       toValue,
       easing,
       duration,
+      delay,
     });
     anim.start(this.props.onAnimationComplete);
 
@@ -86,6 +88,7 @@ AnimatedCircularProgress.propTypes = {
   easing: PropTypes.func,
   onAnimationComplete: PropTypes.func,
   useNativeDriver: PropTypes.bool,
+  delay: PropTypes.number,
 };
 
 AnimatedCircularProgress.defaultProps = {
@@ -93,4 +96,5 @@ AnimatedCircularProgress.defaultProps = {
   easing: Easing.out(Easing.ease),
   prefill: 0,
   useNativeDriver: false,
+  delay: 0,
 };


### PR DESCRIPTION
Adding `delay` prop to the `AnimatedCircularProgress` component. 

This would allow users of this library to provide custom delay for the animation. Tested on the example project that pointed to my fork it seems to be working. Default has been set to 0, so it shouldn't break other apps. This should also address https://github.com/bartgryszko/react-native-circular-progress/issues/137 

Let me know if you have any questions or feedback! 

## Before and After 

**Before**


https://user-images.githubusercontent.com/25942541/135932169-ed152528-2cae-400f-b918-eae235331a91.mp4


**After with 5 seconds delay**

https://user-images.githubusercontent.com/25942541/135931823-92f6851c-c20a-4737-a780-49c5f0a0ae45.mp4

