### PR TITLE
Use deprecated-react-native-prop-types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,10 +4,10 @@ declare module 'react-native-circular-progress' {
     Animated,
     Easing,
     EasingFunction,
-    ViewPropTypes,
     StyleProp,
     ViewStyle
   } from 'react-native';
+  import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
   export interface AnimatedCircularProgressProps {
     /**

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
+    "deprecated-react-native-prop-types": "^2.3.0",
     "react": ">=16.0.0",
     "react-native": ">=0.50.0",
     "react-native-svg": ">=7.0.0"


### PR DESCRIPTION
### Platforms affected
All

### What does this PR do?
RN 0.68 has deprecated and will eventually remove `ViewPropTypes` ([see post](https://github.com/facebook/react-native/issues/21342)). This adds the `deprecated-react-native-prop-types` package and uses that instead.

### What testing has been done on this change?
Local testing, to ensure the deprecation warning has been removed.