### PR TITLE
MSB-791 Add marker to CircularProgress component

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ padding               | number                 | 0                       | Paddi
 dashedBackground      | object                 | { width: 0, gap: 0 }    | Bar background as dashed type
 dashedTint            | object                 | { width: 0, gap: 0 }    | Bar tint as dashed type
 renderCap             | function               | undefined               | Function that's invoked during rendering to draw at the tip of the progress circle
+marker                | number (0-100)         | 0                       | Percentage at which to show a marker on the background line
 
 The following props can further be used on `AnimatedCircularProgress`:
 

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Animated, View } from 'react-native';
-import { Svg, Path, G } from 'react-native-svg';
+import { Svg, Path, G, Circle } from 'react-native-svg';
 
 export default class CircularProgress extends React.PureComponent {
   polarToCartesian(centerX, centerY, radius, angleInDegrees) {
@@ -41,7 +41,8 @@ export default class CircularProgress extends React.PureComponent {
       padding,
       renderCap,
       dashedBackground,
-      dashedTint
+      dashedTint,
+      marker
     } = this.props;
 
     const maxWidthCircle = backgroundWidth ? Math.max(width, backgroundWidth) : width;
@@ -68,6 +69,12 @@ export default class CircularProgress extends React.PureComponent {
       sizeWithPadding,
       radius,
       currentFillAngle
+    );
+    const markerCoordinate = this.polarToCartesian(
+      sizeWithPadding,
+      sizeWithPadding,
+      radius,
+      (arcSweepAngle * this.clampFill(marker)) / 100
     );
     const cap = this.props.renderCap ? this.props.renderCap({ center: coordinate }) : null;
 
@@ -112,6 +119,7 @@ export default class CircularProgress extends React.PureComponent {
                 fill="transparent"
               />
             )}
+            {marker && <Circle cx={markerCoordinate.x} cy={markerCoordinate.y} r={(backgroundWidth || width) / 2} fill={tintColor} />}
             {fill > 0 && (
               <Path
                 d={circlePath}
@@ -151,7 +159,8 @@ CircularProgress.propTypes = {
   padding: PropTypes.number,
   renderCap: PropTypes.func,
   dashedBackground: PropTypes.object,
-  dashedTint: PropTypes.object
+  dashedTint: PropTypes.object,
+  marker: PropTypes.number
 };
 
 CircularProgress.defaultProps = {


### PR DESCRIPTION
This PR adds a circular marker on the background line which takes the same colour as `tintColor`. The `marker` prop works similarly to `fill`: it is a number that represents the percentage at which the marker should be placed.